### PR TITLE
Add numerical test settings in math problem

### DIFF
--- a/stepic_plugins/quizzes/math/__init__.py
+++ b/stepic_plugins/quizzes/math/__init__.py
@@ -4,13 +4,24 @@ from codejail import safe_exec
 
 from stepic_plugins.base import BaseQuiz
 from stepic_plugins.exceptions import FormatError
+from stepic_plugins.utils import parse_decimal
 
 
 class MathQuiz(BaseQuiz):
     name = 'math'
 
     class Schemas:
-        source = {'answer': str}
+        source = {
+            'answer': str,
+            'numerical_test': {
+                'z_re_min': str,
+                'z_re_max': str,
+                'z_im_min': str,
+                'z_im_max': str,
+                'max_error': str,
+                'integer_only': bool,
+            }
+        }
         reply = {'formula': str}
 
     def __init__(self, source):
@@ -18,6 +29,22 @@ class MathQuiz(BaseQuiz):
         self.answer = source.answer
         if not self.answer.strip():
             raise FormatError('Correct answer should be non-empty')
+
+        parse_float = lambda name: float(parse_decimal(getattr(source.numerical_test, name),
+                                                       'numerical_test.{}'.format(name)))
+        self.z_re_min = parse_float('z_re_min')
+        self.z_re_max = parse_float('z_re_max')
+        self.z_im_min = parse_float('z_im_min')
+        self.z_im_max = parse_float('z_im_max')
+        self.max_error = parse_float('max_error')
+        self.integer_only = source.numerical_test.integer_only
+
+        if self.z_re_min > self.z_re_max:
+            raise FormatError('Incorrect Re z')
+        if self.z_im_min > self.z_im_max:
+            raise FormatError('Incorrect Im z')
+        if self.max_error < 0:
+            raise FormatError('Incorrect tolerated absolute error')
 
     def async_init(self):
         global_dict = {'answer': self.answer}
@@ -41,18 +68,42 @@ class MathQuiz(BaseQuiz):
         global_dict = {'matched': False,
                        'hint': '',
                        'answer': self.answer,
+                       'z_re_min': self.z_re_min,
+                       'z_re_max': self.z_re_max,
+                       'z_im_min': self.z_im_min,
+                       'z_im_max': self.z_im_max,
+                       'max_error': self.max_error,
+                       'integer_only': self.integer_only,
                        'reply': reply}
         code = textwrap.dedent("""
+        from random import randint, uniform
+
+        from sympy import I, Tuple, Symbol
         from sympy.parsing.sympy_parser import parse_expr
-        from sympy.utilities.randtest import test_numerically
+        from sympy.utilities.randtest import comp
         from sympy import latex
+
+        def random_number():
+            if integer_only:
+                A, B = randint(z_re_min, z_re_max), randint(z_im_min, z_im_max)
+            else:
+                A, B = uniform(z_re_min, z_re_max), uniform(z_im_min, z_im_max)
+            return A + I*B
+
+        def test_numerically(f, g, z=None):
+            f, g, z = Tuple(f, g, z)
+            z = [z] if isinstance(z, Symbol) else (f.free_symbols | g.free_symbols)
+            reps = list(zip(z, [random_number() for zi in z]))
+            z1 = f.subs(reps).n()
+            z2 = g.subs(reps).n()
+            return comp(z1 - z2, 0, max_error)
 
         def compare(reply, answer):
             if (reply - answer).simplify() == 0:
                 return True
 
             if reply.is_Number and answer.is_Number:
-                return reply == answer
+                return abs(reply - answer) <= max_error
 
             n_tries = 3
             return all(test_numerically(reply, answer) for _ in range(n_tries))

--- a/stepic_plugins/quizzes/math/edit.coffee
+++ b/stepic_plugins/quizzes/math/edit.coffee
@@ -3,6 +3,13 @@ App.MathQuizEditorComponent = Em.Component.extend
     @_super()
     default_source =
       answer: '2*x+y/z'
+      numerical_test:
+        z_re_min: '2'
+        z_re_max: '3'
+        z_im_min: '-1'
+        z_im_max: '1'
+        max_error: '1e-06'
+        integer_only: false
     @set 'source',
       @get('source') || default_source
 

--- a/stepic_plugins/quizzes/math/edit.hbs
+++ b/stepic_plugins/quizzes/math/edit.hbs
@@ -6,4 +6,55 @@
           required="true"}}
 </div>
 <hr>
+<div class="edit-title">Numerical test on random point z (advanced settings):</div>
+<div class="edit-text">
+    <div class="edit-block">
+        <div class="edit-title">Min Re z</div>
+        <div class="edit-text">
+            {{input value=source.numerical_test.z_re_min
+                  class="ember-text-field"
+                  required="true"}}
+        </div>
+    </div>
+    <div class="edit-block">
+        <div class="edit-title">Max Re z</div>
+        <div class="edit-text">
+            {{input value=source.numerical_test.z_re_max
+                  class="ember-text-field"
+                  required="true"}}
+        </div>
+    </div>
+    <div class="edit-block">
+        <div class="edit-title">Min Im z</div>
+        <div class="edit-text">
+            {{input value=source.numerical_test.z_im_min
+                  class="ember-text-field"
+                  required="true"}}
+        </div>
+    </div>
+    <div class="edit-block">
+        <div class="edit-title">Max Im z</div>
+        <div class="edit-text">
+            {{input value=source.numerical_test.z_im_max
+                  class="ember-text-field"
+                  required="true"}}
+        </div>
+    </div>
+    <div class="edit-title">Tolerated absolute error</div>
+    <div class="edit-text">
+        {{input value=source.numerical_test.max_error
+              class="ember-text-field"
+              required="true"}}
+    </div>
+    <div class="options">
+        <label class="option">
+            {{input
+                type="checkbox"
+                name="integer_only"
+                checked=source.numerical_test.integer_only}}
+            <span title="Test on random integer numbers only" class="edit-tooltip">Integer numbers only</span>
+        </label>
+    </div>
+</div>
+<hr>
 <div class="right">See <a href="/lesson/9176">Documentation: Math</a> for docs and examples.</div>

--- a/stepic_plugins/quizzes/math/tests.py
+++ b/stepic_plugins/quizzes/math/tests.py
@@ -5,8 +5,21 @@ from . import MathQuiz
 
 @unittest.skip
 class MathQuizCheckTest(unittest.TestCase):
-    def check(self, answer, reply, result):
-        quiz = MathQuiz(MathQuiz.Source({'answer': answer}))
+    def setUp(self):
+        self.default_numerical_test = {
+            'z_re_min': '2',
+            'z_re_max': '3',
+            'z_im_min': '-1',
+            'z_im_max': '1',
+            'max_error': '1e-06',
+            'integer_only': False,
+        }
+
+    def check(self, answer, reply, result, **kwargs):
+        quiz = MathQuiz(MathQuiz.Source({
+            'answer': answer,
+            'numerical_test': dict(self.default_numerical_test, **kwargs),
+        }))
         self.assertEqual(quiz.check(reply, '')[0], result)
 
     def test_check(self):
@@ -17,6 +30,11 @@ class MathQuizCheckTest(unittest.TestCase):
         self.check('x + y', '2*x + y - x', True)
         self.check('pi', '3.141592', True)
         self.check('pi', '3.1415', False)
+        self.check('pi', '3.1415', True, max_error='1e-04')
         self.check('33**12-(8*33**7-3*33**2)-2*(9*33**8-10*33**4+1)+2*12*33**3+20*33**4-6',
                    '(33**12)-2*(12-3)*(33**(12-4))-(12-4)*(33**(12-5))+2*10*(33**3)*2+6*(33**2)*2',
                    False)
+        self.check('7**7 / (2**2 * 5**5)', '(3.5**3.5 / 2.5**2.5)**2', True)
+        self.check('2*floor(n/2)+n-5', '4*(ceiling(n/2)-3)+3*(1-(n-2*floor(n/2)))+4', False)
+        self.check('2*floor(n/2)+n-5', '4*(ceiling(n/2)-3)+3*(1-(n-2*floor(n/2)))+4', True,
+                   integer_only=True)

--- a/stepic_plugins/quizzes/number/__init__.py
+++ b/stepic_plugins/quizzes/number/__init__.py
@@ -2,6 +2,7 @@ import decimal
 
 from stepic_plugins.base import BaseQuiz
 from stepic_plugins.exceptions import FormatError
+from stepic_plugins.utils import parse_decimal
 
 
 MAX_DIGITS = 50
@@ -45,10 +46,3 @@ class NumberQuiz(BaseQuiz):
                 hint = ''
 
         return score, hint
-
-
-def parse_decimal(s, filed_name):
-    try:
-        return decimal.Decimal(s.replace(',', '.').replace(' ', ''))
-    except decimal.DecimalException:
-        raise FormatError("Field `{}` should be a number".format(filed_name))

--- a/stepic_plugins/utils.py
+++ b/stepic_plugins/utils.py
@@ -1,11 +1,13 @@
+import decimal
 import logging
 import os
 import pwd
 import shutil
 
 import bleach
-
 from codejail import jail_code
+
+from stepic_plugins.exceptions import FormatError
 
 
 logger = logging.getLogger(__name__)
@@ -117,7 +119,7 @@ ALLOWED_ATTRIBUTES = {
     'abbr': ['title'],
     'acronym': ['title'],
     'div': ['class'],
-    'img': ['src', 'alt', 'class', 'title', 'width',  'height'],
+    'img': ['src', 'alt', 'class', 'title', 'width', 'height'],
     'span': ['class'],
     'p': ['class'],
     'code': ['class']
@@ -129,3 +131,10 @@ ALLOWED_STYLES = []
 def clean_html(text):
     return bleach.clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
                         styles=ALLOWED_STYLES, strip=True)
+
+
+def parse_decimal(s, filed_name):
+    try:
+        return decimal.Decimal(s.replace(',', '.').replace(' ', ''))
+    except decimal.DecimalException:
+        raise FormatError("Field `{}` should be a number".format(filed_name))


### PR DESCRIPTION
Настройки численного тестирования в math problem:
* границы числового диапазона;
* допустимая абсолютная ошибка;
* возможность тестирования только на целых числах.

![image](https://cloud.githubusercontent.com/assets/1895251/6871912/f369e438-d4b6-11e4-8c8c-d725f7f10c8f.png)

@vyahhi 