### PR TITLE
add function and context manager to set rpc timeout

### DIFF
--- a/stepic_plugins/__init__.py
+++ b/stepic_plugins/__init__.py
@@ -5,7 +5,7 @@ import subprocess
 import datetime
 import os
 
-VERSION = (2, 0, 0, 'alpha', 0)
+VERSION = (2, 1, 0, 'alpha', 0)
 
 
 def get_version(version=None):


### PR DESCRIPTION
@andrvb
Устанавливаем таймаут глобально для всех вызовов rpc процедур:
```python
set_default_response_timeout(180)
```
или с помощью context manager'а устанавливаем таймаут для одного или нескольких вызовов:
```python
with set_response_timeout(5):
    api.get_static()
```